### PR TITLE
2.1.0 endpoint scope change

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ var logger = require('morgan');
 const fs = require('fs');
 const cors = require('cors');
 const config = require('./config');
-const {getTTL} = require("./services/mysql-connection");
+const {getTTL, getPing, getVersion} = require("./services/mysql-connection");
 const cookieParser = require('cookie-parser');
 
 console.log(config);
@@ -32,6 +32,14 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.get('/api/auth/session-ttl', (req, res) => {
   getTTL(req, res);
+});
+/* GET ping-ping for health checking. */
+app.get('/api/auth/ping', (req, res) => {
+  getPing(req, res);
+});
+/* GET version for health checking and version checking. */
+app.get('/api/auth/version', (req, res) => {
+  getVersion(req, res);
 });
 app.use(createSession({ sessionSecret: config.cookie_secret, session_timeout: config.session_timeout }));
 

--- a/app.js
+++ b/app.js
@@ -33,13 +33,17 @@ app.use(cookieParser());
 app.get('/api/auth/session-ttl', (req, res) => {
   getTTL(req, res);
 });
+
 /* GET ping-ping for health checking. */
-app.get('/api/auth/ping', (req, res) => {
-  getPing(req, res);
+app.get('/api/auth/ping', function (req, res, next) {
+  res.send(`pong`);
 });
+
 /* GET version for health checking and version checking. */
-app.get('/api/auth/version', (req, res) => {
-  getVersion(req, res);
+app.get('/api/auth/version', function (req, res, next) {
+  res.json({
+      version: config.version, date: config.date
+  });
 });
 app.use(createSession({ sessionSecret: config.cookie_secret, session_timeout: config.session_timeout }));
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -60,17 +60,4 @@ router.post('/authenticated', async function (req, res, next) {
     }
 });
 
-
-/* GET ping-ping for health checking. */
-router.get('/ping', function (req, res, next) {
-    res.send(`pong`);
-});
-
-/* GET version for health checking and version checking. */
-router.get('/version', function (req, res, next) {
-    res.json({
-        version: config.version, date: config.date
-    });
-});
-
 module.exports = router;

--- a/services/mysql-connection.js
+++ b/services/mysql-connection.js
@@ -52,4 +52,15 @@ function getSessionIDFromCookie(req, res){
     }
 }
 
+const getPing = (req, res) => {
+    res.send(`pong`);
+}
+const getVersion = (req, res) => {
+    res.json({
+        version: config.version, date: config.date
+    });
+}
+
 exports.getTTL = getTTL;
+exports.getPing = getPing;
+exports.getVersion = getVersion;

--- a/services/mysql-connection.js
+++ b/services/mysql-connection.js
@@ -52,15 +52,4 @@ function getSessionIDFromCookie(req, res){
     }
 }
 
-const getPing = (req, res) => {
-    res.send(`pong`);
-}
-const getVersion = (req, res) => {
-    res.json({
-        version: config.version, date: config.date
-    });
-}
-
 exports.getTTL = getTTL;
-exports.getPing = getPing;
-exports.getVersion = getVersion;


### PR DESCRIPTION
Moved the scope of the ping and version endpoints to be outside of the session timer.